### PR TITLE
ci: Add workflow dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch: {}
   workflow_run:
     workflows: ['CI']
     types:


### PR DESCRIPTION
This PR adds the workflow_dispatch trigger to the release workflow to enable manual workflow runs.

Changes:
- Added workflow_dispatch trigger to release.yml