### PR TITLE
ci: Ensure release workflow only runs on main branch events

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,10 @@ jobs:
   release:
     name: Release
     # Only run if CI was successful and we're on main branch
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR fixes the release workflow to ensure it only runs when the triggering CI workflow was run on main branch.

Changes:
- Added `github.event.workflow_run.head_branch == 'main'` condition to the release job
- This ensures the release workflow only runs when CI passes on main, not on other branches