### PR TITLE
ci: Update Node.js version to 20.8.1 for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20.8.1' # Updated to meet semantic-release requirements
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
This PR updates the Node.js version in the release workflow to meet semantic-release requirements.

Changes:
- Updated Node.js version from 18 to 20.8.1 in release workflow
- This is required by semantic-release as per their documentation: https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md