### PR TITLE
ci: Add Node.js debugging and explicit version handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.8.1' # Updated to meet semantic-release requirements
+          cache: 'pnpm' # Enable pnpm caching
+
+      - name: Debug Node Version
+        run: |
+          echo "Node version:"
+          node --version
+          echo "NPM version:"
+          npm --version
+          which node
+          echo "Node path:"
+          echo $PATH
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
@@ -51,6 +62,12 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
+      - name: Verify Node Version Again
+        run: |
+          echo "Final Node version check:"
+          node --version
+          which node
 
       - name: Release
         env:


### PR DESCRIPTION
This PR adds more explicit Node.js version handling and debugging steps to help diagnose why the release workflow is not using Node.js 20.8.1.

Changes:
- Added `cache: 'pnpm'` to Node.js setup
- Added more debugging steps to print Node.js version and path
- Added a final Node.js version check before running semantic-release