### PR TITLE
ci: Use package.json engines for Node.js version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.8.1' # Updated to meet semantic-release requirements
-          cache: 'pnpm' # Enable pnpm caching
+          node-version-file: 'package.json'
+          cache: 'pnpm'
 
       - name: Debug Node Version
         run: |

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "author": "naaiyy",
   "license": "ISC",
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.8.1",
     "pnpm": ">=8.0.0"
   },
   "repository": {


### PR DESCRIPTION
This PR changes how we specify the Node.js version for the release workflow:

1. Updated `engines` field in `package.json` to require Node.js 20.8.1 or higher
2. Modified the workflow to use `node-version-file: 'package.json'` instead of hardcoding the version

This approach is better because:
- It keeps the Node.js version requirement in one place (`package.json`)
- The workflow will automatically use the version specified in `package.json`
- If we need to update the Node.js version in the future, we only need to change it in one place