### PR TITLE
ci: Use hardcoded Node.js version and npx for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,17 +25,10 @@ jobs:
           persist-credentials: false # Important for semantic-release git plugin
           ref: main # Force checkout of main branch
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: '8'
-          run_install: false
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: 'package.json'
-          cache: 'pnpm'
+          node-version: '20.8.1'
 
       - name: Debug Node Version
         run: |
@@ -46,6 +39,12 @@ jobs:
           which node
           echo "Node path:"
           echo $PATH
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: '8'
+          run_install: false
 
       - name: Get pnpm store directory
         shell: bash
@@ -76,4 +75,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Starting release process..."
-          pnpm semantic-release
+          npx semantic-release

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "author": "naaiyy",
   "license": "ISC",
   "engines": {
-    "node": ">=20.8.1",
+    "node": ">=18.0.0",
     "pnpm": ">=8.0.0"
   },
   "repository": {


### PR DESCRIPTION
This PR changes how we run semantic-release to ensure it uses Node.js 20.8.1:

1. Moved Node.js setup before pnpm installation to ensure it's not overridden
2. Using a hardcoded Node.js version (20.8.1) instead of relying on package.json
3. Using `npx semantic-release` instead of `pnpm semantic-release` to ensure we're using the correct Node.js version
4. Reverted the Node.js version requirement in package.json back to >=18.0.0 since we're not using it anymore

The reason for these changes is that:
1. pnpm was potentially overriding our Node.js version
2. Using `npx` ensures we're using the Node.js version we set up, not pnpm's version
3. We want to keep the project's Node.js requirement at 18+ while allowing semantic-release to run with 20.8.1