### PR TITLE
ci: Update CI workflow to use Node.js 20.8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20.8.1'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
This PR updates the CI workflow to use Node.js 20.8.1 to match the release workflow. This ensures:

1. Consistent Node.js version across all workflows
2. Compatibility with semantic-release which requires Node.js 20.8.1+
3. Forward compatibility as Node.js 18 will reach end-of-life in April 2025

The release workflow was already using Node.js 20.8.1, but having different versions between CI and release could cause issues where packages work in CI but fail in release.