### PR TITLE
ci: Add debug step to check pnpm Node.js version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,15 @@ jobs:
           version: '8'
           run_install: false
 
+      - name: Debug pnpm Node Version
+        run: |
+          echo "pnpm Node version:"
+          pnpm node -v
+          echo "pnpm info:"
+          pnpm config list
+          echo "which node (from pnpm):"
+          pnpm node which node
+
       - name: Get pnpm store directory
         shell: bash
         run: |


### PR DESCRIPTION
Added a debug step to the release workflow to check exactly which Node.js version pnpm is using. This will help us understand why semantic-release is still seeing Node.js 18.20.5 even though we've configured Node.js 20.8.1 in the workflow.