### PR TITLE
ci: Enhance Node.js version debugging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,9 @@ jobs:
           echo "pnpm info:"
           pnpm config list
           echo "which node (from pnpm):"
-          pnpm node which node
+          pnpm exec which node
+          echo "Node version after pnpm:"
+          node -v
 
       - name: Get pnpm store directory
         shell: bash


### PR DESCRIPTION
Enhanced the debug steps in the release workflow to better understand Node.js version changes:

1. Added `node -v` check after pnpm installation
2. Changed `pnpm node which node` to `pnpm exec which node` for better compatibility

This will help us see exactly what version of Node.js is being used at each step.