### PR TITLE
ci: Add pre-commit hook to prevent commits on test branch

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# Run our prevent-test-branch-commits hook
+. "$(dirname -- "$0")/prevent-test-branch-commits"
+
 pnpm lint-staged && pnpm type-check

--- a/.husky/prevent-test-branch-commits
+++ b/.husky/prevent-test-branch-commits
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+
+if [ "$current_branch" = "test/act-workflow" ]; then
+    echo "❌ ERROR: Commits are disabled on test/act-workflow branch"
+    echo "⚠️  This branch is for temporary testing only."
+    echo "💡 If you really need to commit, use --no-verify flag"
+    exit 1
+fi


### PR DESCRIPTION
## Changes

- Add prevent-test-branch-commits hook
- Integrate with existing pre-commit hook
- Ensure no commits can be made on test/act-workflow branch

## Type
- CI change (no version bump)
- Developer tooling improvement