### PR TITLE
fix: Update semantic-release config and untrack tsbuildinfo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,6 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
         run: |
           echo "Starting release process..."

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -24,7 +24,8 @@
     [
       "@semantic-release/npm",
       {
-        "pkgRoot": "."
+        "pkgRoot": ".",
+        "npmPublish": false
       }
     ],
     [

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1,1 +1,0 @@
-{"fileNames":[],"fileInfos":[],"root":[],"options":{"allowJs":true,"esModuleInterop":true,"jsx":1,"module":99,"skipLibCheck":true,"strict":true,"target":9},"errors":true,"version":"5.7.2"}


### PR DESCRIPTION
This PR contains two main changes:

1. Semantic Release Configuration:
   - Disabled npm publishing in semantic-release config
   - Removed NPM_TOKEN from release workflow
   - This will fix the release workflow failures

2. Git Ignore:
   - Untracked tsconfig.tsbuildinfo file while keeping it in .gitignore
   - This prevents the build cache file from being tracked in git