### PR TITLE
fix: Update CI workflow to only trigger on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, staging, development]
+    branches: [main]
   pull_request:
     branches: [main, staging, development]
 


### PR DESCRIPTION
This PR updates the CI workflow to only trigger on pushes to the main branch.

This ensures that the release workflow is only triggered by CI runs on the main branch,
preventing unwanted triggers from other branches.

After this is merged and promoted to main, the release workflow should work as expected.