### PR TITLE
fix(root): Update semantic-release config to handle merge commits

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,8 +10,14 @@
           { "type": "docs", "scope": "README", "release": "patch" },
           { "type": "refactor", "release": "patch" },
           { "type": "style", "release": "patch" },
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
           { "scope": "no-release", "release": false }
-        ]
+        ],
+        "parserOpts": {
+          "mergePattern": "^Merge pull request #(\\d+) from (.*)$",
+          "mergeCorrespondence": ["id", "source"]
+        }
       }
     ],
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
Fix semantic-release not triggering on feat commits through PRs by:

- Adding explicit release rules for feat and fix types
- Configuring merge commit parsing
- This should allow semantic-release to properly analyze merge commits and trigger releases