### PR TITLE
fix(release): Update semantic-release merge pattern to handle all merge types

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,7 +15,8 @@
           { "scope": "no-release", "release": false }
         ],
         "parserOpts": {
-          "mergePattern": "^Merge pull request #(\\d+) from (.*)$",
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"],
+          "mergePattern": "^Merge (pull request #\\d+ from .*|.*into.*)|^chore\\(promote\\): Promote.*$",
           "mergeCorrespondence": ["id", "source"]
         }
       }


### PR DESCRIPTION
This PR updates the semantic-release configuration to better handle different types of merge commits:

- Added support for regular PR merges (`Merge pull request #X from ...`)
- Added support for branch merges (`Merge branch X into Y`)
- Added support for promotion commits (`chore(promote): Promote...`)
- Added proper breaking change detection through `noteKeywords`

This should help semantic-release better analyze the commit history and trigger appropriate releases.