### PR TITLE
chore(promote): Promote staging to main

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,19 @@
+name: Auto-merge Setup
+
+on:
+  pull_request:
+    types: [opened, reopened]
+    branches:
+      - development
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.base_ref == 'development' # Double check we're merging to development
+    steps:
+      - name: Enable auto-merge
+        run: |
+          gh pr merge "$PR_URL" --auto --merge
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,7 +15,8 @@
           { "scope": "no-release", "release": false }
         ],
         "parserOpts": {
-          "mergePattern": "^Merge pull request #(\\d+) from (.*)$",
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"],
+          "mergePattern": "^Merge (pull request #\\d+ from .*|.*into.*)|^chore\\(promote\\): Promote.*$",
           "mergeCorrespondence": ["id", "source"]
         }
       }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,8 +10,14 @@
           { "type": "docs", "scope": "README", "release": "patch" },
           { "type": "refactor", "release": "patch" },
           { "type": "style", "release": "patch" },
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
           { "scope": "no-release", "release": false }
-        ]
+        ],
+        "parserOpts": {
+          "mergePattern": "^Merge pull request #(\\d+) from (.*)$",
+          "mergeCorrespondence": ["id", "source"]
+        }
       }
     ],
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
This PR promotes the following changes from staging to main:

- Updated semantic-release merge pattern to handle all merge types
- Added auto-merge workflow for development PRs

Once merged, this should trigger a new release with proper version bumping based on the commit history.