### PR TITLE
fix(release): Update release workflow Git configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Important for semantic-release
-          persist-credentials: false # Important for semantic-release git plugin
-          ref: main # Force checkout of main branch
           token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
 
       - name: Debug Git Status
@@ -91,6 +89,11 @@ jobs:
           echo "Final Node version check:"
           node --version
           which node
+
+      - name: Configure Git User
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
 
       - name: Release
         env:


### PR DESCRIPTION
This PR fixes the release workflow by:

1. Removing `persist-credentials: false` to allow proper token usage
2. Adding Git user configuration for semantic-release
3. Removing explicit main branch checkout to use the workflow trigger ref

These changes should allow semantic-release to properly create commits and tags during the release process.