### PR TITLE
fix(release): Remove restrictive merge pattern from semantic-release config

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,9 +15,7 @@
           { "scope": "no-release", "release": false }
         ],
         "parserOpts": {
-          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"],
-          "mergePattern": "^Merge (pull request #\\d+ from .*|.*into.*)|^chore\\(promote\\): Promote.*$",
-          "mergeCorrespondence": ["id", "source"]
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
         }
       }
     ],


### PR DESCRIPTION
The release workflow was failing because our semantic-release configuration had a restrictive merge pattern that was preventing it from analyzing merge commits properly. This PR removes that pattern, allowing semantic-release to analyze all commits according to the conventional commits specification.