### PR TITLE
fix(release): Remove npm plugin from semantic-release config

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -27,13 +27,6 @@
       }
     ],
     [
-      "@semantic-release/npm",
-      {
-        "pkgRoot": ".",
-        "npmPublish": false
-      }
-    ],
-    [
       "@semantic-release/github",
       {
         "assets": ["CHANGELOG.md"]
@@ -42,7 +35,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["package.json", "CHANGELOG.md"],
+        "assets": ["CHANGELOG.md"],
         "message": "chore(release): Release version ${nextRelease.version} [skip ci]"
       }
     ]


### PR DESCRIPTION
The release workflow was failing because we had the npm plugin configured but we're not actually publishing to npm. This PR:

- Removes @semantic-release/npm plugin since we're not publishing to npm
- Removes package.json from git assets since we don't need to update it
- Keeps CHANGELOG.md generation and GitHub release creation

This should fix the release workflow by removing unnecessary npm-related steps.