### PR TITLE
chore(promote): Promote development to staging

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -27,13 +27,6 @@
       }
     ],
     [
-      "@semantic-release/npm",
-      {
-        "pkgRoot": ".",
-        "npmPublish": false
-      }
-    ],
-    [
       "@semantic-release/github",
       {
         "assets": ["CHANGELOG.md"]
@@ -42,7 +35,7 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["package.json", "CHANGELOG.md"],
+        "assets": ["CHANGELOG.md"],
         "message": "chore(release): Release version ${nextRelease.version} [skip ci]"
       }
     ]

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,9 +15,7 @@
           { "scope": "no-release", "release": false }
         ],
         "parserOpts": {
-          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"],
-          "mergePattern": "^Merge (pull request #\\d+ from .*|.*into.*)|^chore\\(promote\\): Promote.*$",
-          "mergeCorrespondence": ["id", "source"]
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
         }
       }
     ],


### PR DESCRIPTION
This PR promotes the following changes from development to staging:

- Fixed semantic-release configuration
  - Removed npm plugin since we're not publishing to npm
  - Removed package.json from git assets
  - Simplified the release process