### PR TITLE
fix: Update release workflow token handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Important for semantic-release
-          persist-credentials: false # Don't persist the token
+          fetch-depth: 0
+          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
This PR fixes the release workflow token handling to properly work with protected branches.

## Changes

1. Release Workflow Token Configuration:
   - Added `SEMANTIC_RELEASE_TOKEN` to the checkout step to ensure write permissions
   - Removed `persist-credentials: false` since we need to maintain the token
   - Using the same token for both checkout and release steps

2. Previous Changes (from earlier commit):
   - Added `@semantic-release/changelog` plugin to generate CHANGELOG.md
   - Configured `@semantic-release/npm` to update package.json version

## Expected Behavior
After merging this PR:
1. The release workflow will have proper permissions to push to main
2. Each release will:
   - Generate/update CHANGELOG.md
   - Update package.json version
   - Create GitHub release with notes
   - Push changes back to main branch