### PR TITLE
ci: Update release workflow trigger to run on push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,20 +2,17 @@ name: Release
 
 on:
   workflow_dispatch: {}
-  workflow_run:
-    workflows: ['CI']
-    types:
-      - completed
+  push:
     branches:
       - main
 
 jobs:
   release:
     name: Release
-    # Only run if CI was successful and we're on main branch, or if manually triggered
+    # Only run if manually triggered or push to main branch
     if: |
       (github.event_name == 'workflow_dispatch') ||
-      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -25,9 +22,8 @@ jobs:
       - name: Debug Event
         run: |
           echo "Event name: ${{ github.event_name }}"
-          echo "Workflow run conclusion: ${{ github.event.workflow_run.conclusion }}"
-          echo "Head branch: ${{ github.event.workflow_run.head_branch }}"
-          echo "Head SHA: ${{ github.event.workflow_run.head_sha }}"
+          echo "Branch: ${{ github.ref }}"
+          echo "SHA: ${{ github.sha }}"
 
       - name: Generate token
         id: generate_token


### PR DESCRIPTION
This PR updates the release workflow to:

1. Trigger on push to main instead of workflow_run
2. Simplify the workflow conditions
3. Update debug information

This change will make the release process more reliable by:
- Running directly when changes are merged to main
- Not depending on the CI workflow completion
- Using the GitHub App token for authentication