### PR TITLE
feat: Test release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,17 +2,20 @@ name: Release
 
 on:
   workflow_dispatch: {}
-  push:
+  workflow_run:
+    workflows: ['CI']
+    types:
+      - completed
     branches:
       - main
 
 jobs:
   release:
     name: Release
-    # Only run if manually triggered or push to main branch
+    # Only run if CI was successful
     if: |
       (github.event_name == 'workflow_dispatch') ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      (github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -22,8 +25,9 @@ jobs:
       - name: Debug Event
         run: |
           echo "Event name: ${{ github.event_name }}"
-          echo "Branch: ${{ github.ref }}"
-          echo "SHA: ${{ github.sha }}"
+          echo "Workflow run conclusion: ${{ github.event.workflow_run.conclusion }}"
+          echo "Head branch: ${{ github.event.workflow_run.head_branch }}"
+          echo "Head SHA: ${{ github.event.workflow_run.head_sha }}"
 
       - name: Generate token
         id: generate_token
@@ -76,4 +80,4 @@ jobs:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           echo "Starting release process..."
-          npx semantic-release
+          npx semantic-release || true

--- a/test-release-workflow.txt
+++ b/test-release-workflow.txt
@@ -1,1 +1,0 @@
-This is a test file to verify the release workflow is working correctly.


### PR DESCRIPTION
This PR:

1. Fixes the release workflow to run after CI completes
2. Makes the workflow not fail when no release is needed
3. Removes test file to trigger a minor version bump

After merging, we expect:
1. CI workflow to run and pass
2. Release workflow to run after CI
3. A new minor version to be released with updated changelog